### PR TITLE
feat(DrawCommand): 添加/draw命令的立刻响应, 避免用户长时间等待bot响应

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -121,8 +121,11 @@ async def draw_handler(message: Message, bot: TeleBot) -> None:
         m = message.text.strip().split(maxsplit=1)[1].strip()
     except IndexError:
         await bot.reply_to(message, escape("Please add what you want to draw after /draw. \nFor example: `/draw draw me a cat.`"), parse_mode="MarkdownV2")
-        return    
-    # reply to the message first
+        return
+    
+    # reply to the message first, then delete the "drawing..." message
     drawing_msg = await bot.reply_to(message, "Drawing...")
-    await gemini.gemini_draw(bot, message, m)
-    await bot.delete_message(chat_id=message.chat.id, message_id=drawing_msg.message_id)
+    try:
+        await gemini.gemini_draw(bot, message, m)
+    finally:
+        await bot.delete_message(chat_id=message.chat.id, message_id=drawing_msg.message_id)

--- a/handlers.py
+++ b/handlers.py
@@ -121,5 +121,7 @@ async def draw_handler(message: Message, bot: TeleBot) -> None:
         m = message.text.strip().split(maxsplit=1)[1].strip()
     except IndexError:
         await bot.reply_to(message, escape("Please add what you want to draw after /draw. \nFor example: `/draw draw me a cat.`"), parse_mode="MarkdownV2")
-        return
+        return    
+    # reply to the message first
+    await bot.reply_to(message, "Drawing...")
     await gemini.gemini_draw(bot, message, m)

--- a/handlers.py
+++ b/handlers.py
@@ -123,5 +123,6 @@ async def draw_handler(message: Message, bot: TeleBot) -> None:
         await bot.reply_to(message, escape("Please add what you want to draw after /draw. \nFor example: `/draw draw me a cat.`"), parse_mode="MarkdownV2")
         return    
     # reply to the message first
-    await bot.reply_to(message, "Drawing...")
+    drawing_msg = await bot.reply_to(message, "Drawing...")
     await gemini.gemini_draw(bot, message, m)
+    await bot.delete_message(chat_id=message.chat.id, message_id=drawing_msg.message_id)


### PR DESCRIPTION
### 问题描述
用户在使用 `/draw` 命令时，可能会因为图片生成时间较长并且bot无任何响应以为bot卡住了

### 解决方案
在用户输入`/draw`命令时，机器人会立即回复用户 "Drawing..."，以提供即时反馈

### 更改内容
- 在原有代码中添加了一行 `await bot.reply_to(message, "Drawing...")`。

### 测试
- 手动测试了 `/draw` 命令，确认机器人能够正确回复 "Drawing..."。
- 确保图片生成流程不受影响。