### PR TITLE
fix:更改为可用模型

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,8 +4,8 @@ conf = {
     "before_generate_info": "🤖Generating🤖",
     "download_pic_notify":  "🤖Loading picture🤖",
     "model_1":              "gemini-2.5-flash-preview-04-17",
-    "model_2":              "gemini-2.5-pro-exp-03-25",
-    "model_3":              "gemini-2.0-flash-exp",#for draw
+    "model_2":              "gemini-2.5-pro-preview-05-06",
+    "model_3":              "gemini-2.0-flash-preview-image-generation",#for draw
     "streaming_update_interval": 0.5,  # Streaming answer update interval (seconds)
 }
 


### PR DESCRIPTION
更换pro模型为gemini-2.5-pro-preview-05-06
更换图像模型为gemini-2.0-flash-preview-image-generation
原有exp模型已停止使用
无论是否付费都无法使用